### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ Just use an exported function to name the action, and a destructured object to d
 
 `npm install flambeau --save`
 
-## Actions
+## Documentation
+
+- [Actions](docs/actions.md)
+- [Reducers](docs/reducers.md)
+- [Using with Redux](docs/redux.md)
+
+## Example
+
+### Actions
 
 ```javascript
 // actions/TodoListActions.js
@@ -43,7 +51,7 @@ export function importTodosFromURL({ URL }, { currentActionSet }) {
 }
 ```
 
-## Reducer
+### Reducer
 
 ```javascript
 // reducers/TodoListReducer.js
@@ -60,7 +68,7 @@ export const TodoListActions = {
 }
 ```
 
-## Using with Redux
+### Using with Redux
 
 ```javascript
 import { createStore, applyMiddleware } from 'redux';
@@ -77,7 +85,7 @@ export const store = createStoreWithMiddleware(rootReducer, initialState);
 export const connectedActionSets = connectActionSetsToStore({ actionSets, store });
 ```
 
-## Introspection
+### Introspection
 
 Introspection with the `getConsensus()` function allows actions to request data from reducers whilst keeping them completely decoupled. Action creators have no knowledge of the specifics of reducers’ state.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flambeau
-A lightweight Flux (& Redux compatible) library with opinions:
+A lightweight, Redux-compatible Flux library with opinions:
 
 ### Declarative action creators
 ```javascript
@@ -10,14 +10,28 @@ export function addTodo({ text }) {} // No constants, self-documenting payload
 - **Async action support built-in**, with convenient dispatching of other actions.
 
 ### Reusable reducers
-- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, inside an exported object with the same name as the action set.
+```javascript
+export const TodoListActions = {
+  addTodo(state, { text }) {
+    return state.concat({ text });
+  }
+}
+```
+- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, within an exported object with the same name as the action set.
 - **Redux-style reducers** instead of stores, using pure functions to allow clear data flow and immutability.
+```javascript
+export function getInitialState({ initialItems = [] }) {
+  return {
+    items: initialItems
+  };
+}
+```
 - **Reusable reducers, using props to customize** the initial state or response to actions.
 - **Bulk forwarding of action sets** within reducers to allow easy composition of reducers, such as in collections or other hierarchies.
 
-### Reducer encapsulation
-- **Introspection methods to allow encapsulation** of reducers’ internal state.
-- Get a **consensus for async actions**, such as whether something needs loading, by polling reducers using their introspection methods. This removes coupling between reducers and actions, allowing greater code reuse.
+### Reducer state encapsulation
+- **Introspection methods to allow encapsulation** of reducers’ internal state. This removes action creators’ knowledge of the store’s structure, allowing greater code reuse.
+- Get a **consensus for async actions**, such as whether something needs loading, by polling reducers using their introspection methods.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flambeau
 A lightweight Flux (& Redux compatible) library with opinions:
 
-### Declarative Action Creators
+### Declarative action creators
 ```javascript
 export function addTodo({ text }) {} // No constants, self-documenting payload
 ```
@@ -9,13 +9,13 @@ export function addTodo({ text }) {} // No constants, self-documenting payload
 - Better organized actions with simple **namespacing** using action sets.
 - **Async action support built-in**, with convenient dispatching of other actions.
 
-### Reusable Reducers
+### Reusable reducers
 - **No switch statements** to handle actions, just declare a function with the same name as the action’s function, inside an exported object with the same name as the action set.
 - **Redux-style reducers** instead of stores, using pure functions to allow clear data flow and immutability.
 - **Reusable reducers, using props to customize** the initial state or response to actions.
 - **Bulk forwarding of action sets** within reducers to allow easy composition of reducers, such as in collections or other hierarchies.
 
-### Reducer Encapsulation
+### Reducer encapsulation
 - **Introspection methods to allow encapsulation** of reducers’ internal state.
 - Get a **consensus for async actions**, such as whether something needs loading, by polling reducers using their introspection methods. This removes coupling between reducers and actions, allowing greater code reuse.
 
@@ -30,112 +30,5 @@ export function addTodo({ text }) {} // No constants, self-documenting payload
 - [Using with Redux](docs/redux.md)
 
 ## Example
-
-### Actions
-
-```javascript
-// actions/TodoListActions.js
-
-import fetch from 'isomorphic-fetch';
-
-// Simple action, which documents its payload, unlike a constant.
-export function addTodo({ text }) {}
-
-// Asynchronous action. Just add a second argument and use `currentActionSet` to
-// dispatch any number of actions.
-export function importTodosFromURL({ URL }, { currentActionSet }) {
-  fetch(URL)
-  .then(response => response.json())
-  .then(items => {
-    items.forEach(item => {
-      currentActionSet.addTodo({ text: item.text });
-    });
-  })
-}
-```
-
-### Reducer
-
-```javascript
-// reducers/TodoListReducer.js
-
-export function getInitialState() {
-  return [];
-}
-
-// Namespaced to action sets
-export const TodoListActions = {
-  addTodo(state, { text }) {
-    return state.concat({ text });
-  }
-}
-```
-
-### Using with Redux
-
-```javascript
-import { createStore, applyMiddleware } from 'redux';
-import { createRootReducer, connectActionSetsToStore } from 'flambeau/redux';
-import actionSets from '../actions';
-import reducers from '../reducers';
-
-const createStoreWithMiddleware = applyMiddleware(
-  // All your favorite redux middleware
-)(createStore);
-
-const rootReducer = createRootReducer({ reducers, idToProps: {} });
-export const store = createStoreWithMiddleware(rootReducer, initialState);
-export const connectedActionSets = connectActionSetsToStore({ actionSets, store });
-```
-
-### Introspection
-
-Introspection with the `getConsensus()` function allows actions to request data from reducers whilst keeping them completely decoupled. Action creators have no knowledge of the specifics of reducers’ state.
-
-```javascript
-import fetch from 'isomorphic-fetch';
-
-// Simple action
-export function invalidateReddit({ reddit }) {}
-
-export function requestPosts({ reddit }) {}
-
-// Action that transforms its requested payload
-export function receivePosts({ reddit, json }) {
-  return {
-    reddit,
-    posts: json.data.children.map(child => child.data),
-    receivedAt: Date.now()
-  };
-}
-
-// Helper function that is not exported
-function fetchPosts({ reddit }, { currentActionSet }) {
-  currentActionSet.requestPosts({ reddit });
-
-  fetch(`http://www.reddit.com/r/${reddit}.json`)
-    .then(response => response.json())
-    .then(json => currentActionSet.receivePosts({ reddit, json }))
-  ;
-}
-
-// Methods of introspection that this action set requests that reducers implement.
-export const introspection = {
-  shouldFetchPosts({ reddit }) {}
-}
-
-// Asynchronous action, receiving extra arguments to send other actions or poll reducers for a consensus.
-export function fetchPostsIfNeeded({ reddit }, { currentActionSet, getConsensus }) {
-  if (getConsensus({
-    introspectionID: 'shouldFetchPosts',
-    payload: { reddit },
-    booleanOr: true
-  })) {
-    fetchPosts({ reddit }, { currentActionSet });
-  };
-}
-```
-
-## Full Example
 
 See the [async redux demo example](examples/async-redux) for a full example of introspection and the features of Flambeau.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 A lightweight Flux (& Redux compatible) library with opinions:
 
 ### Declarative Action Creators
-- Better structured actions with **namespacing** and **no UPPERCASE_CONSTANTS**.
-Just use an exported function to name the action, and a destructured object to document the payload.
-- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, inside an exported object with the same name as the action set.
+```javascript
+export function addTodo({ text }) {} // No constants, self-documenting payload
+```
+- **No UPPERCASE_CONSTANTS**. Just use an exported function to name the action, and a destructured object to document the payload.
+- Better organized actions with simple **namespacing** using action sets.
 - **Async action support built-in**, with convenient dispatching of other actions.
 
 ### Reusable Reducers
-- **Reducers** instead of stores, using pure functions to allow clear data flow and immutability.
-- Reducer can be **reused, using props to customize** initial state or the response to actions.
+- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, inside an exported object with the same name as the action set.
+- **Redux-style reducers** instead of stores, using pure functions to allow clear data flow and immutability.
+- **Reusable reducers, using props to customize** the initial state or response to actions.
 - **Bulk forwarding of action sets** within reducers to allow easy composition of reducers, such as in collections or other hierarchies.
 
 ### Reducer Encapsulation
@@ -135,4 +138,4 @@ export function fetchPostsIfNeeded({ reddit }, { currentActionSet, getConsensus 
 
 ## Full Example
 
-See the [async redux example](examples/async-redux) for a full example of introspection and the features of Flambeau.
+See the [async redux demo example](examples/async-redux) for a full example of introspection and the features of Flambeau.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A lightweight, Redux-compatible Flux library with opinions:
 ```javascript
 export function addTodo({ text }) {} // No constants, self-documenting payload
 ```
-- Better organized actions with simple **namespacing** using action sets.
+- Better organized actions with **namespacing** using action sets.
 - **Async action support built-in**, with convenient dispatching of other actions.
 
 ### Reusable reducers
-- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, within an exported object with the same name as the action set.
+- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, within an exported object named after the action set.
 ```javascript
 export const TodoListActions = {
   addTodo(state, { text }) {

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 A lightweight, Redux-compatible Flux library with opinions:
 
 ### Declarative action creators
+- **No UPPERCASE_CONSTANTS**. Just use an exported function to name the action, and a destructured object to document the payload.
 ```javascript
 export function addTodo({ text }) {} // No constants, self-documenting payload
 ```
-- **No UPPERCASE_CONSTANTS**. Just use an exported function to name the action, and a destructured object to document the payload.
 - Better organized actions with simple **namespacing** using action sets.
 - **Async action support built-in**, with convenient dispatching of other actions.
 
 ### Reusable reducers
+- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, within an exported object with the same name as the action set.
 ```javascript
 export const TodoListActions = {
   addTodo(state, { text }) {
@@ -17,8 +18,8 @@ export const TodoListActions = {
   }
 }
 ```
-- **No switch statements** to handle actions, just declare a function with the same name as the action’s function, within an exported object with the same name as the action set.
 - **Redux-style reducers** instead of stores, using pure functions to allow clear data flow and immutability.
+- **Reusable reducers, using props to customize** the initial state or response to actions.
 ```javascript
 export function getInitialState({ initialItems = [] }) {
   return {
@@ -26,7 +27,6 @@ export function getInitialState({ initialItems = [] }) {
   };
 }
 ```
-- **Reusable reducers, using props to customize** the initial state or response to actions.
 - **Bulk forwarding of action sets** within reducers to allow easy composition of reducers, such as in collections or other hierarchies.
 
 ### Reducer state encapsulation

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -5,7 +5,7 @@
 Action sets group multiple action creators into one namespace.
 
 The recommended way to declare an action set is to create a file with the name
-of action set, e.g. *TodoActions.js*. Then declare action creators and
+of action set, e.g. *TodoListActions.js*. Then declare action creators and
 introspection methods, which are detailed below.
 
 ## Action Creators
@@ -52,16 +52,12 @@ or `allActionSets.myActionSetID.myActionID(payload)`.
 import fetch from 'isomorphic-fetch';
 
 export function addTodo({ text }) {}
-export function didTodosImportFromURL({ text }) {}
+export function addTodosFromURL({ items }) {}
 
 export function importTodosFromURL({ URL }, { currentActionSet, allActionSets }) {
   fetch(URL)
   .then(response => response.json())
-  .then(items => {
-    items.forEach(item => {
-      currentActionSet.addTodo({ text: item.text });
-    });
-  })
+  .then(items => currentActionSet.addTodosFromURL({ items }));
 }
 ```
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,0 +1,93 @@
+# Actions
+
+## Action Sets
+
+Action sets group multiple action creators into one namespace.
+
+The recommended way to declare an action set is to create a file with the name
+of action set, e.g. *TodoActions.js*. Then declare action creators and
+introspection methods, which are detailed below.
+
+## Action Creators
+
+Flambeau’s action creators are declarative. There is no need for
+UPPERCASE_CONSTANTS. Simply export a function, with its name identifying the
+action creator, and a destructured object (`{ anything, you, like }`) for the
+first argument as the payload.
+
+The body of the function can be left empty, if the payload is to be used as-is.
+Or if you would like to add other properties or transform the payload in some
+way, then return the customized payload you would like.
+
+e.g.
+```javascript
+export function addTodo({ text }) {}
+
+export function addTodoWithCurrentDate({ text }) {
+  return {
+    dateCreated: new Date(),
+    text
+  };
+}
+```
+
+## Async Action Creators
+
+Asynchronous action creators allow operations such as loading or saving to be
+encapsulated.
+These action creators forward to other actions that reducers can listen to.
+
+Simple add a second argument to your action creator, with a destructured object
+including the following optional properties:
+- `currentActionSet`: The action set you are currently declaring within,
+allowing you to dispatch sibling actions. Maps action identifiers to individual
+dispatcher functions.
+- `allActionSets`: All the action sets, mapping action set identifiers to sets
+of dispatcher functions.
+
+To forward to another action, use either `currentActionSet.myActionID(payload)`
+or `allActionSets.myActionSetID.myActionID(payload)`.
+
+```javascript
+import fetch from 'isomorphic-fetch';
+
+export function addTodo({ text }) {}
+export function didTodosImportFromURL({ text }) {}
+
+export function importTodosFromURL({ URL }, { currentActionSet, allActionSets }) {
+  fetch(URL)
+  .then(response => response.json())
+  .then(items => {
+    items.forEach(item => {
+      currentActionSet.addTodo({ text: item.text });
+    });
+  })
+}
+```
+
+## Introspection
+
+Flambeau allows action creators to query reducers with the concept of
+'introspection', which is similar to interfaces or protocols in other
+programming languages.
+
+Reducers implement introspection methods, returning results from within its
+state. This completely encapsulates the specifics of the state’s structure.
+Unlike the use of Redux’s `getState`, action creators are never tied to a
+particular reducer.
+
+Declaring introspection methods:
+```javascript
+export const introspection = {
+  hasImportedFromURL({ URL }) {},
+  hasTodoContainingText({ text }) {}
+};
+```
+
+Introspection methods can then be called within an asynchronous action creator
+by using the `getConsensus` function.
+
+---
+
+For information on how to respond to actions, read the [reducers](reducers.md)
+section.

--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -33,7 +33,7 @@ The only difference from action creators is the current state is passed as the
 first argument.
 
 ```javascript
-export const TodoActions = {
+export const TodoListActions = {
   addTodo(state, { text }) {
     return state.concat({ text });
   }

--- a/docs/reducers.md
+++ b/docs/reducers.md
@@ -1,0 +1,54 @@
+# Reducers
+
+## Props
+
+Reducers in Flambeau are differentiated from the standard Redux reducer by a
+number of modest features. One of these is the addition of props for reducers.
+
+These props allow both the initial state and the state transformation during an
+action to be customized. Like React’s props, their use is encouraged to enable
+reducers to be less hard-coded and more reusable.
+
+## Initial State
+
+The initial state in Flambeau is determined by a declaration of the exported
+function `getInitialState`. The props are passed as the first argument.
+
+```javascript
+export function getInitialState({ initialTodos = [] }) {
+  return initialTodos;
+}
+```
+
+## Implementing Action Responders
+
+Responding to actions is done in a similar manner to action creators: by
+declaring functions. The name of the function mirrors that of the action
+creator. The functions are declared in a vanilla JavaScript object, named the
+same as the action set.
+
+The only difference from action creators is the current state is passed as the
+first argument.
+
+```javascript
+export const TodoActions = {
+  addTodo(state, { text }) {
+    return state.concat({ text });
+  }
+}
+```
+
+## Composing
+
+Reducers can be easily composed within each other. This allows you to break your
+reducers into multiple pieces.
+
+Forwarding actions is possible, especially easily done in bulk per action set.
+To forward an action, declare an action set as a function instead of an object.
+When an action from this set is dispatched, this function will be called with
+the following parameters.
+- `type`
+- `actionID`
+- `payload`
+- `props`
+- `forwardTo()`

--- a/docs/redux.md
+++ b/docs/redux.md
@@ -1,0 +1,29 @@
+# Redux Support
+
+Flambeau is built to be composable, in a style inspired from Redux.
+
+Because Flambeau’s action creators and reducers are declarative, you don’t need
+to import Flambeau into their files. The only thing you need to import is
+'flambeau/redux' into your Redux store.
+
+Two functions are provided:
+- `createRootReducer({ reducers, idToProps })`: Creates a Redux compatible
+reducer. Pass your props, mapping the reducer ID to specific props.
+- `connectActionSetsToStore()`: Connects your action sets to the Redux store. It
+is recommended that you export this object, to be used within your controller
+components (in React).
+
+```javascript
+import { createStore, applyMiddleware } from 'redux';
+import { createRootReducer, connectActionSetsToStore } from 'flambeau/redux';
+import actionSets from '../actions';
+import reducers from '../reducers';
+
+const createStoreWithMiddleware = applyMiddleware(
+  // All your favorite redux middleware
+)(createStore);
+
+const rootReducer = createRootReducer({ reducers, idToProps: {} });
+export const store = createStoreWithMiddleware(rootReducer, initialState);
+export const connectedActionSets = connectActionSetsToStore({ actionSets, store });
+```

--- a/docs/redux.md
+++ b/docs/redux.md
@@ -13,17 +13,61 @@ reducer. Pass your props, mapping the reducer ID to specific props.
 is recommended that you export this object, to be used within your controller
 components (in React).
 
+Here is an example of integrating Redux with Flambeau:
+
 ```javascript
 import { createStore, applyMiddleware } from 'redux';
 import { createRootReducer, connectActionSetsToStore } from 'flambeau/redux';
 import actionSets from '../actions';
-import reducers from '../reducers';
+import reducers, { idToProps } from '../reducers';
 
 const createStoreWithMiddleware = applyMiddleware(
-  // All your favorite redux middleware
+  // All your favorite Redux middleware
 )(createStore);
 
-const rootReducer = createRootReducer({ reducers, idToProps: {} });
+const rootReducer = createRootReducer({ reducers, idToProps });
 export const store = createStoreWithMiddleware(rootReducer, initialState);
 export const connectedActionSets = connectActionSetsToStore({ actionSets, store });
 ```
+
+It is expected that `actions` and `reducers` would be directories exporting all
+action sets and reducers, like the following:
+
+```javascript
+// actions/index.js
+
+import * as TodoItemActions from './TodoItemActions';
+import * as TodoListActions from './TodoListActions';
+
+export default {
+  TodoItemActions,
+  TodoListActions
+};
+```
+
+```javascript
+// reducers/index.js
+
+import * as TodoListReducer from './TodoListReducer';
+
+export default {
+  list: TodoListReducer
+};
+
+export const idToProps = {
+  list: {
+    initialItems: [
+      {
+        text: 'Read Flambeau documentation',
+        isCompleted: true
+      }
+    ]
+  }
+}
+```
+
+---
+
+For any questions or suggestions for Flambeau, please
+[file an issue](https://github.com/BurntCaramel/flambeau/issues) or email me
+(found at my [GitHub profile](https://github.com/BurntCaramel)).

--- a/src/callAction.js
+++ b/src/callAction.js
@@ -2,10 +2,10 @@ import isFunction from './isFunction';
 import { ACTION_TYPE, INTROSPECTION_TYPE } from './types';
 
 
-export default function callAction({ responder, type, initialValue, actionSetID, actionID, payload, notFoundValue, props }) {
+export default function callAction({ responder, type, initialState, actionSetID, actionID, payload, notFoundValue, props }) {
   const responderFunction = findActionResponder({ responder, type, actionSetID, actionID, notFoundValue });
   if (responderFunction !== notFoundValue) {
-    return responderFunction(initialValue, payload, { props });
+    return responderFunction(initialState, payload, { props });
   }
   else {
     return notFoundValue;
@@ -17,15 +17,15 @@ function findActionResponder({ responder, type, actionSetID, actionID, notFoundV
   if (responder[actionSetID]) {
     // Has forwarding function for entire type
     if (isFunction(responder[actionSetID])) {
-      return (initialValue, payload, props) => {
-        function forwardTo(responder, initialValue) {
+      return (initialState, payload, props) => {
+        function forwardTo({ responder, initialState }) {
           return callAction({
-            notFoundValue: initialValue,
-            responder, type, initialValue, actionSetID, actionID, payload, props
+            notFoundValue: initialState,
+            responder, type, initialState, actionSetID, actionID, payload, props
           });
         }
 
-        const result = responder[actionSetID](initialValue, {
+        const result = responder[actionSetID](initialState, {
           isAction: (type === ACTION_TYPE),
           isIntrospection: (type === INTROSPECTION_TYPE),
           type, actionID, payload, props, forwardTo

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -11,7 +11,7 @@ export default ({ resources, states }) => ({ actionSetID, actionID, payload }) =
     const result = callAction({
       responder: reducer,
       type: ACTION_TYPE,
-      initialValue: states[resourceID],
+      initialState: states[resourceID],
       props,
       payload,
       notFoundValue,

--- a/src/getConsensus.js
+++ b/src/getConsensus.js
@@ -20,7 +20,7 @@ export default ({ resources, states }) => ({ actionSetID }) => ({ introspectionI
     const currentValue = callAction({
       responder: reducer,
       type: INTROSPECTION_TYPE,
-      initialValue: states[resourceID],
+      initialState: states[resourceID],
       props,
       actionID: introspectionID,
       actionSetID,


### PR DESCRIPTION
- Add documentation for action creators, reducers, and Redux integration.
- Remove lengthy examples from README, as documentation does a better job explaining the concepts with inline examples.
